### PR TITLE
Force OpenStack Client version to be 1.0.1.

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -788,7 +788,7 @@ if use_library_from_git "python-openstackclient"; then
     git_clone_by_name "python-openstackclient"
     setup_dev_lib "python-openstackclient"
 else
-    pip_install python-openstackclient
+    pip_install python-openstackclient==1.0.1
 fi
 
 


### PR DESCRIPTION
This prevents a version conflict against the latest
global-requirements.txt regarding oslo.config.

Closes-bug: #1433126