### PR TITLE
Renaming "stackforge" references to "openstack"

### DIFF
--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -139,25 +139,24 @@ They are added in the following format::
 
 An example would be as follows::
 
-  enable_plugin ec2api git://git.openstack.org/stackforge/ec2api
+  enable_plugin ec2api git://git.openstack.org/openstack/ec2api
 
 Plugins for gate jobs
 ---------------------
 
 All OpenStack plugins that wish to be used as gate jobs need to exist
-in OpenStack's gerrit. Both ``openstack`` namespace and ``stackforge``
-namespace are fine. This allows testing of the plugin as well as
+in OpenStack's gerrit. This allows testing of the plugin as well as
 provides network isolation against upstream git repository failures
 (which we see often enough to be an issue).
 
 Ideally plugins will be implemented as ``devstack`` directory inside
-the project they are testing. For example, the stackforge/ec2-api
+the project they are testing. For example, the openstack/ec2-api
 project has it's pluggin support in it's tree.
 
 In the cases where there is no "project tree" per say (like
 integrating a backend storage configuration such as ceph or glusterfs)
 it's also allowed to build a dedicated
-``stackforge/devstack-plugin-FOO`` project to house the plugin.
+``openstack/devstack-plugin-FOO`` project to house the plugin.
 
 Note jobs must not require cloning of repositories during tests.
 Tests must list their repository in the ``PROJECTS`` variable for

--- a/local.conf
+++ b/local.conf
@@ -12,24 +12,24 @@ Q_SERVICE_PLUGIN_CLASSES=neutron.services.l3_router.l3_router_plugin.L3RouterPlu
 
 GIT_BASE=http://github.com
 
-GBPSERVICE_REPO=${GIT_BASE}/stackforge/group-based-policy.git
+GBPSERVICE_REPO=${GIT_BASE}/openstack/group-based-policy.git
 GBPSERVICE_BRANCH=stable/kilo
-#GBPSERVICE_REPO=https://review.openstack.org/stackforge/group-based-policy
+#GBPSERVICE_REPO=https://review.openstack.org/openstack/group-based-policy
 #GBPSERVICE_BRANCH=refs/changes/20/130920/6
 
-GBPCLIENT_REPO=${GIT_BASE}/stackforge/python-group-based-policy-client.git
+GBPCLIENT_REPO=${GIT_BASE}/openstack/python-group-based-policy-client.git
 GBPCLIENT_BRANCH=stable/kilo
-#GBPCLIENT_REPO=https://review.openstack.org/stackforge/python-group-based-policy-client
+#GBPCLIENT_REPO=https://review.openstack.org/openstack/python-group-based-policy-client
 #GBPCLIENT_BRANCH=refs/changes/56/130056/13
 
-GBPUI_REPO=${GIT_BASE}/stackforge/group-based-policy-ui.git
+GBPUI_REPO=${GIT_BASE}/openstack/group-based-policy-ui.git
 GBPUI_BRANCH=stable/kilo
-#GBPUI_REPO=https://review.openstack.org/stackforge/group-based-policy-ui
+#GBPUI_REPO=https://review.openstack.org/openstack/group-based-policy-ui
 #GBPUI_BRANCH=refs/changes/02/136802/14
 
-GBPHEAT_REPO=${GIT_BASE}/stackforge/group-based-policy-automation.git
+GBPHEAT_REPO=${GIT_BASE}/openstack/group-based-policy-automation.git
 GBPHEAT_BRANCH=stable/kilo
-#GBPHEAT_REPO=GBPHEAT_REPO=https://review.openstack.org/stackforge/group-based-policy-automation
+#GBPHEAT_REPO=GBPHEAT_REPO=https://review.openstack.org/openstack/group-based-policy-automation
 #GBPHEAT_BRANCH=refs/changes/45/170845/2
 
 # Enable neutron for group-policy-poc

--- a/stackrc
+++ b/stackrc
@@ -175,19 +175,19 @@ GIT_BASE=${GIT_BASE:-git://git.openstack.org}
 #
 ##############
 # group-based-policy service
-GBPSERVICE_REPO=${GBPSERVICE_REPO:-${GIT_BASE}/stackforge/group-based-policy.git}
+GBPSERVICE_REPO=${GBPSERVICE_REPO:-${GIT_BASE}/openstack/group-based-policy.git}
 GBPSERVICE_BRANCH=${GBPSERVICE_BRANCH:-master}
 
 # group-based-policy client
-GBPCLIENT_REPO=${GBPCLIENT_REPO:-${GIT_BASE}/stackforge/python-group-based-policy-client.git}
+GBPCLIENT_REPO=${GBPCLIENT_REPO:-${GIT_BASE}/openstack/python-group-based-policy-client.git}
 GBPCLIENT_BRANCH=${GBPCLIENT_BRANCH:-master}
 
 # group-based-policy automation
-GBPHEAT_REPO=${GBPHEAT_REPO:-${GIT_BASE}/stackforge/group-based-policy-automation.git}
+GBPHEAT_REPO=${GBPHEAT_REPO:-${GIT_BASE}/openstack/group-based-policy-automation.git}
 GBPHEAT_BRANCH=${GBPHEAT_BRANCH:-master}
 
 # group-based-policy ui
-GBPUI_REPO=${GBPUI_REPO:-${GIT_BASE}/stackforge/group-based-policy-ui.git}
+GBPUI_REPO=${GBPUI_REPO:-${GIT_BASE}/openstack/group-based-policy-ui.git}
 GBPUI_BRANCH=${GBPUI_BRANCH:-master}
 
 # telemetry service
@@ -443,7 +443,7 @@ GITREPO["keystonemiddleware"]=${KEYSTONEMIDDLEWARE_REPO:-${GIT_BASE}/openstack/k
 GITBRANCH["keystonemiddleware"]=${KEYSTONEMIDDLEWARE_BRANCH:-master}
 
 # s3 support for swift
-SWIFT3_REPO=${SWIFT3_REPO:-${GIT_BASE}/stackforge/swift3.git}
+SWIFT3_REPO=${SWIFT3_REPO:-${GIT_BASE}/openstack/swift3.git}
 SWIFT3_BRANCH=${SWIFT3_BRANCH:-master}
 
 # ceilometer middleware


### PR DESCRIPTION
This makes it possible to use OpenStack git mirrors that do
not support the stackforge->openstack redirection.
